### PR TITLE
Add diffbgcolors for Git 2.29

### DIFF
--- a/gitk
+++ b/gitk
@@ -30,3 +30,4 @@ set indexcirclecolor #50fa7b
 set circlecolors {#282a36 #bd93f9 #44475a #bd93f9 #bd93f9}
 set linkfgcolor #bd93f9
 set circleoutlinecolor #44475a
+set diffbgcolors {{#342a36} #283636}


### PR DESCRIPTION
gitk in Git 2.29 added separate background colors for old and new diff lines, but the defaults are light and need to be adjusted to dark.

Before:

![Screenshot from 2020-11-09 15-21-50](https://user-images.githubusercontent.com/26471/98603543-130da700-2297-11eb-9455-728e199acf06.png)

After:

![Screenshot from 2020-11-09 15-22-30](https://user-images.githubusercontent.com/26471/98603552-16a12e00-2297-11eb-8800-d771fb1362dc.png)
